### PR TITLE
Python3.4+ Compatibility, packaging fixes, tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+source = ciscoipphone
+
+[report]
+exclude_lines =
+    if __name__ == '__main__':

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyo
 *.swp
 .DS_Store
+.idea/
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "nightly"
+branches:
+  only:
+    - master
+install:
+  - pip install -r requirements.txt
+  - pip install -e .
+script:
+  - py.test --cov -v -r f
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,8 @@ Will render:
 
 .. code:: xml
 
+    <?xml version="1.0" ?>
+
     <CiscoIPPhoneMenu>
       <MenuItem>
         <URL>http://server/directory/contacts</URL>
@@ -64,6 +66,8 @@ Will render:
       </MenuItem>
       <Prompt>Select a directory</Prompt>
     </CiscoIPPhoneMenu>
+
+
 
 Generating ``CiscoIPPhoneDirectory``
 ------------------------------------
@@ -82,6 +86,7 @@ Will render:
 .. code:: xml
 
     <?xml version="1.0" ?>
+
     <CiscoIPPhoneDirectory>
       <DirectoryEntry>
         <Telephone>18442391546</Telephone>
@@ -99,3 +104,4 @@ Will render:
       <Prompt>Select a contact</Prompt>
       <Title>My Contacts</Title>
     </CiscoIPPhoneDirectory>
+

--- a/ciscoipphone/__init__.py
+++ b/ciscoipphone/__init__.py
@@ -7,8 +7,13 @@ __author__ = 'Nick Ficano'
 __license__ = 'MIT License'
 __copyright__ = 'Copyright 2015 Nick Ficano'
 
+# from . import base, services, utils
+#
+# __all__ = [base, services, utils]
+
 # Set default logging handler to avoid "No handler found" warnings.
 import logging
+
 try:  # Python 2.7+
     from logging import NullHandler
 except ImportError:

--- a/ciscoipphone/base.py
+++ b/ciscoipphone/base.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env/python
 # -*- coding: utf-8 -*-
 from ciscoipphone.utils import DictToXML
+from six import add_metaclass
 
 
 class CiscoServiceOptions(object):
@@ -24,9 +25,8 @@ class DeclarativeMetaclass(type):
         new_class._meta = CiscoServiceOptions(opts)
         return new_class
 
-
+@add_metaclass(DeclarativeMetaclass)
 class CiscoService(object):
-    __metaclass__ = DeclarativeMetaclass
 
     def __init__(self, **kwargs):
         self.data = {}

--- a/ciscoipphone/services.py
+++ b/ciscoipphone/services.py
@@ -45,7 +45,7 @@ class Menu(CiscoService):
         service_name = 'CiscoIPPhoneMenu'
         fields = ['Prompt', 'Title', 'MenuItem']
 
-    def add(self, name, url):
+    def add_item(self, name, url):
         self.items.append(MenuItem(name=name, url=url))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-cov
+six
+xmltodict

--- a/setup.py
+++ b/setup.py
@@ -2,23 +2,24 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from setuptools import setup, find_packages
-from itertools import ifilter
 from os import path
 from ast import parse
-import pip
-requirements = pip.req.parse_requirements("requirements.txt",
-                                          session=pip.download.PipSession())
 
-pip_requirements = [str(r.req) for r in requirements]
+try:
+    # Python2
+    from future_builtins import filter
+except ImportError:
+    # Python3
+    pass
 
-with open('README.rst') as readme_file:
-    readme = readme_file.read()
+with open('README.rst') as license_file:
+    readme = license_file.read()
 
-with open('LICENSE.txt') as readme_file:
-    license = readme_file.read()
+with open('LICENSE.txt') as license_file:
+    license = license_file.read()
 
 with open(path.join('ciscoipphone', '__init__.py')) as f:
-    __version__ = parse(next(ifilter(
+    __version__ = parse(next(filter(
         lambda line: line.startswith('__version__'), f))).body[0].value.s
 
 setup(
@@ -32,8 +33,8 @@ setup(
                  "generating and deploying Cisco IP phone directory "
                  "services."),
     zip_safe=False,
-    install_requires=pip_requirements,
     long_description=readme,
+    install_requires=['six'],
     license=license,
     classifiers=[
         "Programming Language :: Python :: 2.7",

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,15 @@ except ImportError:
     # Python3
     pass
 
-with open('README.rst') as license_file:
-    readme = license_file.read()
+with open('README.rst') as file:
+    readme = file.read()
 
-with open('LICENSE.txt') as license_file:
-    license = license_file.read()
+with open('LICENSE.txt') as file:
+    license = file.read()
 
-with open(path.join('ciscoipphone', '__init__.py')) as f:
+with open(path.join('ciscoipphone', '__init__.py')) as file:
     __version__ = parse(next(filter(
-        lambda line: line.startswith('__version__'), f))).body[0].value.s
+        lambda line: line.startswith('__version__'), file))).body[0].value.s
 
 setup(
     name='ciscoipphone',

--- a/tests/readme_ciscoipphone_expected
+++ b/tests/readme_ciscoipphone_expected
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<CiscoIPPhoneMenu>
+  <MenuItem>
+    <URL>http://server/directory/contacts</URL>
+    <Name>My Contacts</Name>
+  </MenuItem>
+  <MenuItem>
+    <URL>http://server/directory/businesses</URL>
+    <Name>Businesses</Name>
+  </MenuItem>
+  <Prompt>Select a directory</Prompt>
+</CiscoIPPhoneMenu>
+

--- a/tests/readme_ciscoipphonedirectory_expected
+++ b/tests/readme_ciscoipphonedirectory_expected
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<CiscoIPPhoneDirectory>
+  <DirectoryEntry>
+    <Telephone>18442391546</Telephone>
+    <Name>Avon Barksdale</Name>
+  </DirectoryEntry>
+  <DirectoryEntry>
+    <Telephone>18993712775</Telephone>
+    <Name>Stringer Bell</Name>
+  </DirectoryEntry>
+  <SoftKeyItem>
+    <URL>SoftKey:Dial</URL>
+    <Position>1</Position>
+    <Name>Dial</Name>
+  </SoftKeyItem>
+  <Prompt>Select a contact</Prompt>
+  <Title>My Contacts</Title>
+</CiscoIPPhoneDirectory>
+

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,26 @@
+from tests.testingutils import compare_xml_strings, get_test_file
+from ciscoipphone.services import Menu, Directory
+
+class TestReadme(object):
+    def test_generating_ciscoipphonemenu(self, capsys):
+        expected = get_test_file('readme_ciscoipphone_expected')
+
+        menu = Menu(prompt="Select a directory")
+        menu.add_item("My Contacts", "http://server/directory/contacts")
+        menu.add_item("Businesses", "http://server/directory/businesses")
+        menu.prettify()
+        received, err = capsys.readouterr()
+
+        assert compare_xml_strings(expected, received)
+
+    def test_generating_CiscoIpPhoneDirectory(self, capsys):
+        expected = get_test_file('readme_ciscoipphonedirectory_expected')
+
+        directory = Directory(prompt='Select a contact', title='My Contacts')
+        directory.add_entry('Avon Barksdale', 18442391546)
+        directory.add_entry('Stringer Bell', 18993712775)
+        directory.add_softkey('Dial', 'SoftKey:Dial', 1)
+        directory.prettify()
+        received, err = capsys.readouterr()
+
+        assert compare_xml_strings(expected, received)

--- a/tests/testingutils.py
+++ b/tests/testingutils.py
@@ -1,0 +1,77 @@
+import os
+
+import xmltodict
+
+
+def list_equal(list1, list2):
+    for i in list1:
+        try:
+            list2_index = list2.index(i)
+            i2 = list2[list2_index]
+        except IndexError:
+            return False
+
+        if isinstance(i, dict):
+            if not dictionary_equal(i, i2):
+                return False
+            else:
+                continue
+
+        if isinstance(i, list):
+            if not list_equal(i, i2):
+                return False
+            else:
+                continue
+
+        if i != i2:
+            return False
+    return True
+
+
+def dictionary_equal(dict1, dict2):
+    for key, value in dict1.items():
+        # Check if we can even get element
+        try:
+            dict2value = dict2[key]
+        except KeyError:
+            return False
+
+        # If another dictionary loop
+        if isinstance(value, dict) and isinstance(dict2value, dict):
+            if not dictionary_equal(value, dict2value):
+                return False
+            else:
+                continue
+
+        # If list send to list equal comparator
+        if isinstance(value, list) and isinstance(dict2value, list):
+            if not list_equal(value, dict2value):
+                return False
+            else:
+                continue
+
+        # Must be regular value lets compare
+        if value != dict2value:
+            return False
+
+    return True
+
+
+def compare_xml_strings(xmls1, xmls2):
+    xmldict_1 = xmltodict.parse(xmls1, encoding='utf8', dict_constructor=dict)
+    xmldict_2 = xmltodict.parse(xmls2, encoding='utf8', dict_constructor=dict)
+
+    if dictionary_equal(xmldict_1, xmldict_2):
+        return True
+    else:
+        return False
+
+
+def get_path(filename):
+    path = os.path.join(os.path.dirname(__file__), filename)
+    return path
+
+
+def get_test_file(filename):
+    with open(get_path(filename), 'r') as file:
+        return file.read()


### PR DESCRIPTION
initial coverage and ci commit
update requirements for test runners
initial smoketest for ci build to hopefully pass on python27
initial import fix and cleanup of setup.py
functional tests and adjustments to match readme
Menu.add != Menu.add_item in readme, updated method
passing tests with python3 support
using a complicated process, at least to me, to compare the xml formats. There may be a better way and the code itself doing the comparison should probably be pulled out and tested itself.